### PR TITLE
fix install buildpack errand error handling

### DIFF
--- a/jobs/install-hwc-buildpack/templates/run.ps1.erb
+++ b/jobs/install-hwc-buildpack/templates/run.ps1.erb
@@ -1,19 +1,30 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
+function runCf {
+  param(
+    [string]$command
+  )
+
+  cf $command
+  if ($LASTEXITCODE -ne 0) {
+    Exit $LASTEXITCODE
+  }
+}
+
 $env:Path += ";C:\var\vcap\packages\cf-cli\bin"
 $env:CF_USERNAME="<%= p("cf.admin_username") %>"
 $env:CF_PASSWORD="<%= p("cf.admin_password") %>"
 $env:API_URL="<%= p("cf.api_url") %>"
 $env:SKIP_SSL_VALIDATION="<%= p("ssl.skip_cert_verify") %>"
 
-if ( $Env:SKIP_SSL_VALIDATION -eq "true" ) {
-  cf api $Env:API_URL --skip-ssl-validation
+if ( $env:SKIP_SSL_VALIDATION -eq "true" ) {
+  runCf "api $env:API_URL --skip-ssl-validation"
 } else {
-  cf api $Env:API_URL
+  runCf "api $env:API_URL"
 }
 
-cf auth $Env:CF_USERNAME $Env:CF_PASSWORD
+runCf "auth $env:CF_USERNAME $env:CF_PASSWORD"
 
 $hwcBuildpack = Get-Item("C:\var\vcap\packages\hwc-buildpack\hwc*.zip")
 
@@ -21,21 +32,21 @@ $hasBuildpack = $false
 $unlocked = $false
 
 $option = [System.StringSplitOptions]::RemoveEmptyEntries
-$buildpacks = (cf buildpacks).Split("\n", $option)
+$buildpacks = (runCf "buildpacks").Split("\n", $option)
 
 foreach ($bp in $buildpacks) {
-	$bpName, $bpPos, $bpEnabled, $bpLocked, $ignore = $bp.Split(" ", $option)
+  $bpName, $bpPos, $bpEnabled, $bpLocked, $ignore = $bp.Split(" ", $option)
 
-	if ($bpName -eq "hwc_buildpack") {
-		$hasBuildpack = $true
-		$unlocked = ($bpLocked -eq "false")
-	}
+  if ($bpName -eq "hwc_buildpack") {
+    $hasBuildpack = $true
+    $unlocked = ($bpLocked -eq "false")
+  }
 }
 
 if (-not $hasBuildpack) {
-	cf create-buildpack hwc_buildpack $hwcBuildpack 1 --enable
+  runCf "create-buildpack hwc_buildpack $hwcBuildpack 1 --enable"
 } elseif ($unlocked) {
-	cf update-buildpack hwc_buildpack -p $hwcBuildpack
+  runCf "update-buildpack hwc_buildpack -p $hwcBuildpack"
 } else {
-	Write-Host "HWC Buildpack is locked, skipping update"
+  Write-Host "HWC Buildpack is locked, skipping update"
 }


### PR DESCRIPTION
If the cf processes used to push the buildpack exit with an error, the errand still succeeds when it should fail.

[#140807055](https://www.pivotaltracker.com/story/show/140807055)

```
Director task 105
  Started preparing deployment > Preparing deployment. Done (00:00:03)

  Started preparing package compilation > Finding packages to compile. Done (00:00:00)

  Started creating missing vms > install-hwc-buildpack/208ee737-2bd0-460e-b9f7-f64ee9ea0f69 (0). Done (00:02:13)

  Started updating instance install-hwc-buildpack > install-hwc-buildpack/208ee737-2bd0-460e-b9f7-f64ee9ea0f69 (0) (canary). Done (00:03:48)

  Started running errand > install-hwc-buildpack/0. Done (00:00:03)

  Started fetching logs for install-hwc-buildpack/208ee737-2bd0-460e-b9f7-f64ee9ea0f69 (0) > Finding and packing log files. Done (00:00:01)

  Started deleting errand instances install-hwc-buildpack > install-hwc-buildpack/208ee737-2bd0-460e-b9f7-f64ee9ea0f69 (0). Done (00:00:55)

Task 105 done

Started2017-02-28 21:42:11 UTC
Finished2017-02-28 21:49:14 UTC
Duration00:07:03

[stdout]
Setting api endpoint to [36;1mhttps://CF_API_ENDPOINT[0m...
[31;1mFAILED[0m
FAILED
No API endpoint set. Use 'cf login' or 'cf api' to target an endpoint.
FAILED
No API endpoint set. Use 'cf login' or 'cf api' to target an endpoint.

[stderr]
Invalid SSL Cert for https://api.sys.agate-hornet.gcp.releng.cf-app.com/v2/info
TIP: Use 'cf api --skip-ssl-validation' to continue with an insecure API endpoint

Errand 'install-hwc-buildpack' completed successfully (exit code 0)
```