### PR TITLE
Remove windows2016 stack support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,7 +10,3 @@ hwc-buildpack/hwc_buildpack-windows2012R2-v3.1.10.zip:
   size: 12916484
   object_id: 65e6d446-8fa9-45ae-6f33-bc8dc4a8cd7e
   sha: sha256:56cb471e5de8f8229cfe7229069ac92da7edc770f2e1b7537740a20d4646cc8f
-hwc-buildpack/hwc_buildpack-windows2016-v3.1.10.zip:
-  size: 12916449
-  object_id: 0306c405-3225-4da5-6425-d7d2de0984f8
-  sha: sha256:8554e435ec8223e806b85862461e8e61195bb0f39269ec3d9255a9b438c48cc4

--- a/jobs/hwc-buildpack/spec
+++ b/jobs/hwc-buildpack/spec
@@ -5,7 +5,6 @@ templates: {}
 
 packages:
 - hwc-buildpack-windows
-- hwc-buildpack-windows2016
 - hwc-buildpack-windows2012R2
 
 properties: {}

--- a/packages/hwc-buildpack-windows2016/packaging
+++ b/packages/hwc-buildpack-windows2016/packaging
@@ -1,2 +1,0 @@
-set -e -x
-cp hwc-buildpack/hwc?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/hwc-buildpack-windows2016/spec
+++ b/packages/hwc-buildpack-windows2016/spec
@@ -1,5 +1,0 @@
----
-name: hwc-buildpack-windows2016
-
-files:
-- hwc-buildpack/hwc?buildpack-windows2016*.zip


### PR DESCRIPTION
This change removes `hwc_buildpack-windows2016` from the release.

The `windows2016` stack is no longer supported. See [cloudfoundry docs](https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html):

> "If you push your Cloud Foundry app to a Windows stack, you must use windows. The `windows2016` stack is not supported on Cloud Foundry."

`windows2016` and `windows` stacks are equivalent, but `windows2016` was deprecated and is now being removed to avoid confusion.